### PR TITLE
Update calendar_lang.php

### DIFF
--- a/language/bulgarian/calendar_lang.php
+++ b/language/bulgarian/calendar_lang.php
@@ -10,13 +10,13 @@
  */
 defined('BASEPATH') OR exit('No direct script access allowed');
 
-$lang['cal_su'] = 'Не';
-$lang['cal_mo'] = 'По';
+$lang['cal_su'] = 'Нд';
+$lang['cal_mo'] = 'Пн';
 $lang['cal_tu'] = 'Вт';
 $lang['cal_we'] = 'Ср';
-$lang['cal_th'] = 'Че';
-$lang['cal_fr'] = 'Пе';
-$lang['cal_sa'] = 'Съ';
+$lang['cal_th'] = 'Чт';
+$lang['cal_fr'] = 'Пт';
+$lang['cal_sa'] = 'Сб';
 $lang['cal_sun'] = 'Нед';
 $lang['cal_mon'] = 'Пон';
 $lang['cal_tue'] = 'Вто';


### PR DESCRIPTION
In Bulgarian we're not using vowels (like "a", "o", "e") when we have 2 letters abbreviation...