### PR TITLE
Use accented uppercase in the French translation

### DIFF
--- a/language/french/profiler_lang.php
+++ b/language/french/profiler_lang.php
@@ -8,17 +8,17 @@
  */
 defined('BASEPATH') OR exit('No direct script access allowed');
 
-$lang['profiler_database']        = 'BASE DE DONNEES';
-$lang['profiler_controller_info'] = 'CLASSE/METHODE';
+$lang['profiler_database']        = 'BASE DE DONNÉES';
+$lang['profiler_controller_info'] = 'CLASSE/MÉTHODE';
 $lang['profiler_benchmarks']      = 'BENCHMARKS';
-$lang['profiler_queries']         = 'REQUETES';
-$lang['profiler_get_data']        = 'DONNEES GET';
-$lang['profiler_post_data']       = 'DONNEES POST';
+$lang['profiler_queries']         = 'REQUÊTES';
+$lang['profiler_get_data']        = 'DONNÉES GET';
+$lang['profiler_post_data']       = 'DONNÉES POST';
 $lang['profiler_uri_string']      = 'URI STRING';
-$lang['profiler_memory_usage']    = 'UTILISATION MEMOIRE';
+$lang['profiler_memory_usage']    = 'UTILISATION MÉMOIRE';
 $lang['profiler_config']          = 'VARIABLES CONFIG';
-$lang['profiler_session_data']    = 'DONNEES SESSION';
-$lang['profiler_headers']         = 'EN-TETES HTTP';
+$lang['profiler_session_data']    = 'DONNÉES SESSION';
+$lang['profiler_headers']         = 'EN-TÊTES HTTP';
 $lang['profiler_no_db']           = "Le driver de la base de données n'est actuellement pas chargé";
 $lang['profiler_no_queries']      = "Aucune requête n'a été exécutée";
 $lang['profiler_no_post']         = "Aucune donnée POST n'existe";


### PR DESCRIPTION
This adds accented uppercase characters in capitalized strings, which makes them easier to read.