### PR TITLE
A new message for valid_mac in form_validation portuguese-brazillian

### DIFF
--- a/language/portuguese-brazilian/form_validation_lang.php
+++ b/language/portuguese-brazilian/form_validation_lang.php
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 /**
  * System messages translation for CodeIgniter(tm)
  *
@@ -15,6 +15,7 @@ $lang['form_validation_valid_email'] = 'O campo {field} deve conter um email vá
 $lang['form_validation_valid_emails'] = 'O campo {field} deve conter apenas emails válidos.';
 $lang['form_validation_valid_url'] = 'O campo {field} deve conter uma URL válida.';
 $lang['form_validation_valid_ip'] = 'O campo {field} deve conter um IP válido.';
+$lang['form_validation_valid_mac'] = 'O campo {field} deve conter um MAC válido.';
 $lang['form_validation_valid_base64'] = 'O campo {field} deve conter um valor Base64 válido.';
 $lang['form_validation_min_length'] = 'O campo {field} deve ter pelo menos {param} caractere(s).';
 $lang['form_validation_max_length'] = 'O campo {field} ultrapassou o limite de {param} caractere(s).';


### PR DESCRIPTION
Hello, please add this message. In **form_validation** the **valid_mac** method is present in [current version](https://github.com/bcit-ci/CodeIgniter/blob/develop/system/language/english/form_validation_lang.php)