### PR TITLE
Language files, Copyright update and typos correction for Portuguese

### DIFF
--- a/language/portuguese/calendar_lang.php
+++ b/language/portuguese/calendar_lang.php
@@ -3,7 +3,7 @@
  * System messages translation for CodeIgniter(tm)
  *
  * @author	CodeIgniter community
- * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @copyright	Copyright (c) 2014-2020, British Columbia Institute of Technology (https://bcit.ca/)
  * @license	http://opensource.org/licenses/MIT	MIT License
  * @link	https://codeigniter.com
  */

--- a/language/portuguese/date_lang.php
+++ b/language/portuguese/date_lang.php
@@ -3,7 +3,7 @@
  * System messages translation for CodeIgniter(tm)
  *
  * @author	CodeIgniter community
- * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @copyright	Copyright (c) 2014-2020, British Columbia Institute of Technology (https://bcit.ca/)
  * @license	http://opensource.org/licenses/MIT	MIT License
  * @link	https://codeigniter.com
  */
@@ -63,5 +63,5 @@ $lang['UP115']  = '(UTC +11:30) Ilha Norfolk';
 $lang['UP12']   = '(UTC +12:00) Fiji, Ilhas Gilbert, Zona de Kamchatka, Nova Zelândia';
 $lang['UP1275'] = '(UTC +12:45) Ilhas Chatham';
 $lang['UP13']   = '(UTC +13:00) Ilhas Fénix, Tonga';
-$lang['UP14']   = '(UTC +14:00) Ilhas da linha';
+$lang['UP14']   = '(UTC +14:00) Ilhas da Linha';
 

--- a/language/portuguese/db_lang.php
+++ b/language/portuguese/db_lang.php
@@ -3,7 +3,7 @@
  * System messages translation for CodeIgniter(tm)
  *
  * @author	CodeIgniter community
- * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @copyright	Copyright (c) 2014-2020, British Columbia Institute of Technology (https://bcit.ca/)
  * @license	http://opensource.org/licenses/MIT	MIT License
  * @link	https://codeigniter.com
  */
@@ -19,7 +19,7 @@ $lang['db_must_use_set'] = 'Tem que usar o método "set" para atualizar uma entr
 $lang['db_must_use_index'] = 'Tem que indicar o index que quer comparar nas atualizações em massa.';
 $lang['db_batch_missing_index'] = 'Falta o index a uma ou mais linhas submetidas para a atualização em massa.';
 $lang['db_must_use_where'] = 'Só é possível fazer atualizações se tiver a cláusula "where".';
-$lang['db_del_must_use_where'] = 'Só é possível apagar se tiver a cláulusa "where" ou "like".';
+$lang['db_del_must_use_where'] = 'Só é possível apagar se tiver a cláusula "where" ou "like".';
 $lang['db_field_param_missing'] = 'É necessário o nome da tabela como um parâmetro para conseguir ir buscar os campos.';
 $lang['db_unsupported_function'] = 'Esta funcionalidade não está disponível para a base de dados que está a usar.';
 $lang['db_transaction_failure'] = 'Falha de transação. Foi reposto o estado anterior (rollback).';
@@ -27,9 +27,9 @@ $lang['db_unable_to_drop'] = 'Não é possível apagar a base de dados indicada'
 $lang['db_unsupported_feature'] = 'Esta funcionalidade não é suportada pela plataforma de base de dados que está a usar.';
 $lang['db_unsupported_compression'] = 'O formato de compressão de ficheiros que escolheu não é suportado pelo seu servidor.';
 $lang['db_filepath_error'] = 'Incapaz de escrever dados no caminho de ficheiro que indicou.';
-$lang['db_invalid_cache_path'] = 'O cainho da cache que indicou não é válido ou não é tem permissões de escrita.';
-$lang['db_table_name_required'] = 'É necessário um nome de tabela para essa operação.';
-$lang['db_column_name_required'] = 'É necessário um nome de coluna para essa operação.';
-$lang['db_column_definition_required'] = 'É necessário uma definição de coluna para essa operação.';
+$lang['db_invalid_cache_path'] = 'O caminho da cache que indicou não é válido ou não é tem permissões de escrita.';
+$lang['db_table_name_required'] = 'É necessário um nome de tabela para esta operação.';
+$lang['db_column_name_required'] = 'É necessário um nome de coluna para esta operação.';
+$lang['db_column_definition_required'] = 'É necessário uma definição de coluna para esta operação.';
 $lang['db_unable_to_set_charset'] = 'Incapaz de definir o set de caratéres da ligação ao cliente: %s';
 $lang['db_error_heading'] = 'Ocorreu um erro na base de dados';

--- a/language/portuguese/email_lang.php
+++ b/language/portuguese/email_lang.php
@@ -3,7 +3,7 @@
  * System messages translation for CodeIgniter(tm)
  *
  * @author	CodeIgniter community
- * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @copyright	Copyright (c) 2014-2020, British Columbia Institute of Technology (https://bcit.ca/)
  * @license	http://opensource.org/licenses/MIT	MIT License
  * @link	https://codeigniter.com
  */

--- a/language/portuguese/form_validation_lang.php
+++ b/language/portuguese/form_validation_lang.php
@@ -3,7 +3,7 @@
  * System messages translation for CodeIgniter(tm)
  *
  * @author	CodeIgniter community
- * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @copyright	Copyright (c) 2014-2020, British Columbia Institute of Technology (https://bcit.ca/)
  * @license	http://opensource.org/licenses/MIT	MIT License
  * @link	https://codeigniter.com
  */
@@ -16,6 +16,7 @@ $lang['form_validation_valid_emails']           = 'O campo {field} deve conter t
 $lang['form_validation_valid_url']              = 'O campo {field} deve conter um URL válido.';
 $lang['form_validation_valid_ip']               = 'O campo {field} deve conter um IP válido.';
 $lang['form_validation_valid_mac']              = 'O campo {field} deve conter um endereço MAC válido.';
+$lang['form_validation_valid_base64']			= 'O campo {field} deve conter uma string Base64 válida.';
 $lang['form_validation_min_length']             = 'O campo {field} deve conter pelo menos {param} caracteres.';
 $lang['form_validation_max_length']             = 'O campo {field} não pode conter mais que {param} caracteres.';
 $lang['form_validation_exact_length']           = 'O campo {field} deve conter exatamente {param} caracteres.';

--- a/language/portuguese/ftp_lang.php
+++ b/language/portuguese/ftp_lang.php
@@ -3,7 +3,7 @@
  * System messages translation for CodeIgniter(tm)
  *
  * @author	CodeIgniter community
- * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @copyright	Copyright (c) 2014-2020, British Columbia Institute of Technology (https://bcit.ca/)
  * @license	http://opensource.org/licenses/MIT	MIT License
  * @link	https://codeigniter.com
  */
@@ -17,7 +17,7 @@ $lang['ftp_unable_to_changedir']    = 'Incapaz de mudar de diretorias.';
 $lang['ftp_unable_to_chmod']        = 'Incapaz de definir as permissões do ficheiro. Por favor confira o caminho do ficheiro.';
 $lang['ftp_unable_to_upload']       = 'Incapaz de fazer o upload do ficheiro especificado. Por favor confira o caminho do ficheiro.';
 $lang['ftp_unable_to_download']     = 'Incapaz de fazer o download do ficheiro especificado. Por favor confira o caminho do ficheiro.';
-$lang['ftp_no_source_file']         = 'Incaapz de localizar o ficheiro de origem. Por favor confira o caminho do ficheiro.';
+$lang['ftp_no_source_file']         = 'Incapaz de localizar o ficheiro de origem. Por favor confira o caminho do ficheiro.';
 $lang['ftp_unable_to_rename']       = 'Incapaz de mudar o nome ao ficheiro.';
-$lang['ftp_unable_to_delete']       = 'Incaapz de apagar o ficheiro.';
-$lang['ftp_unable_to_move']         = 'Incapaz de mover o ficheiro. Por favor certifique-se que a diretoria de detino existe..';
+$lang['ftp_unable_to_delete']       = 'Incapaz de apagar o ficheiro.';
+$lang['ftp_unable_to_move']         = 'Incapaz de mover o ficheiro. Por favor certifique-se que a diretoria de destino existe..';

--- a/language/portuguese/imglib_lang.php
+++ b/language/portuguese/imglib_lang.php
@@ -3,19 +3,20 @@
  * System messages translation for CodeIgniter(tm)
  *
  * @author	CodeIgniter community
- * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @copyright	Copyright (c) 2014-2020, British Columbia Institute of Technology (https://bcit.ca/)
  * @license	http://opensource.org/licenses/MIT	MIT License
  * @link	https://codeigniter.com
  */
 defined('BASEPATH') OR exit('No direct script access allowed');
 
-$lang['imglib_source_image_required'] = 'Tem que especificar uma imagem de origem nas suas definiçãoes.';
+$lang['imglib_source_image_required'] = 'Tem que especificar uma imagem de origem nas suas definições.';
 $lang['imglib_gd_required'] = 'A biblioteca de imagem GD é necessária para esta funcionalidade.';
 $lang['imglib_gd_required_for_props'] = 'O seu servidor tem que suportar a biblioteca de imagem GD para poder consultar as propriedades da imagem.';
 $lang['imglib_unsupported_imagecreate'] = 'O seu servidor não suporta a função GD necessária para processar este tipo de imagem.';
 $lang['imglib_gif_not_supported'] = 'As imagens GIF geralmente não são suportadas por questões de licenciamento. Pode ter que usar imagens JPG ou PNG como alternativa.';
 $lang['imglib_jpg_not_supported'] = 'Imagens JPG não são suportadas.';
 $lang['imglib_png_not_supported'] = 'Imagens PNG não são suportadas.';
+$lang['imglib_webp_not_supported'] = 'Imagens WEBP não são suportadas.';
 $lang['imglib_jpg_or_png_required'] = 'O protocolo de redimensionamento de imagens especificado nas suas definições só funciona com os tipos de imagem JPG ou PNG.';
 $lang['imglib_copy_error'] = 'Ocorreu um erro ao tentar substituir o ficheiro. Por favor certifique-se que tem permissões de escrita na diretoria do ficheiro.';
 $lang['imglib_rotate_unsupported'] = 'O seu servidor parece não suportar a rotação da imagem.';

--- a/language/portuguese/migration_lang.php
+++ b/language/portuguese/migration_lang.php
@@ -3,7 +3,7 @@
  * System messages translation for CodeIgniter(tm)
  *
  * @author	CodeIgniter community
- * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @copyright	Copyright (c) 2014-2020, British Columbia Institute of Technology (https://bcit.ca/)
  * @license	http://opensource.org/licenses/MIT	MIT License
  * @link	https://codeigniter.com
  */

--- a/language/portuguese/number_lang.php
+++ b/language/portuguese/number_lang.php
@@ -3,7 +3,7 @@
  * System messages translation for CodeIgniter(tm)
  *
  * @author	CodeIgniter community
- * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @copyright	Copyright (c) 2014-2020, British Columbia Institute of Technology (https://bcit.ca/)
  * @license	http://opensource.org/licenses/MIT	MIT License
  * @link	https://codeigniter.com
  */

--- a/language/portuguese/pagination_lang.php
+++ b/language/portuguese/pagination_lang.php
@@ -3,7 +3,7 @@
  * System messages translation for CodeIgniter(tm)
  *
  * @author	CodeIgniter community
- * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @copyright	Copyright (c) 2014-2020, British Columbia Institute of Technology (https://bcit.ca/)
  * @license	http://opensource.org/licenses/MIT	MIT License
  * @link	https://codeigniter.com
  */

--- a/language/portuguese/profiler_lang.php
+++ b/language/portuguese/profiler_lang.php
@@ -3,7 +3,7 @@
  * System messages translation for CodeIgniter(tm)
  *
  * @author	CodeIgniter community
- * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @copyright	Copyright (c) 2014-2020, British Columbia Institute of Technology (https://bcit.ca/)
  * @license	http://opensource.org/licenses/MIT	MIT License
  * @link	https://codeigniter.com
  */

--- a/language/portuguese/unit_test_lang.php
+++ b/language/portuguese/unit_test_lang.php
@@ -3,7 +3,7 @@
  * System messages translation for CodeIgniter(tm)
  *
  * @author	CodeIgniter community
- * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @copyright	Copyright (c) 2014-2020, British Columbia Institute of Technology (https://bcit.ca/)
  * @license	http://opensource.org/licenses/MIT	MIT License
  * @link	https://codeigniter.com
  */

--- a/language/portuguese/upload_lang.php
+++ b/language/portuguese/upload_lang.php
@@ -3,7 +3,7 @@
  * System messages translation for CodeIgniter(tm)
  *
  * @author	CodeIgniter community
- * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @copyright	Copyright (c) 2014-2020, British Columbia Institute of Technology (https://bcit.ca/)
  * @license	http://opensource.org/licenses/MIT	MIT License
  * @link	https://codeigniter.com
  */
@@ -13,7 +13,7 @@ $lang['upload_userfile_not_set'] = 'Não foi possível encontrar uma variável P
 $lang['upload_file_exceeds_limit'] = 'O ficheiro carregado tem um tamanho superior ao permitido pelo ficheiro de configuração do PHP.';
 $lang['upload_file_exceeds_form_limit'] = 'O ficheiro carregado tem um tamanho superior ao definido no formulário.';
 $lang['upload_file_partial'] = 'O ficheiro não foi carregado na totalidade.';
-$lang['upload_no_temp_directory'] = 'A pasta temporária desapareceu.';
+$lang['upload_no_temp_directory'] = 'A pasta temporária não existe.';
 $lang['upload_unable_to_write_file'] = 'Não foi possível guardar o ficheiro.';
 $lang['upload_stopped_by_extension'] = 'O upload do ficheiro parou por causa da sua extensão.';
 $lang['upload_no_file_selected'] = 'Não selecionou nenhum ficheiro para fazer o upload.';


### PR DESCRIPTION
- Updated the copyright to 2014-2020 and corrected some misspelled words.
- Updated files with need translations to match CodeIgniter 3.1-stable English files (also included 2 translations present in develop version, for future proof, that being the base64 and the webp messages)

Portuguese manager, does not maintain the Portuguese translation anymore. I am available to take the position..