### PR TITLE
Inserted required attribute `lang` in html tags

### DIFF
--- a/language/arabic/index.html
+++ b/language/arabic/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/armenian/index.html
+++ b/language/armenian/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/azerbaijani/index.html
+++ b/language/azerbaijani/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/basque/index.html
+++ b/language/basque/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/bengali/index.html
+++ b/language/bengali/index.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/bosnian/index.html
+++ b/language/bosnian/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Zabranjeno</title>
 </head>

--- a/language/bulgarian/index.html
+++ b/language/bulgarian/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/catalan/index.html
+++ b/language/catalan/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/croatian/index.html
+++ b/language/croatian/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Zabranjeno</title>
 </head>

--- a/language/czech/index.html
+++ b/language/czech/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/danish/index.html
+++ b/language/danish/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/dutch/index.html
+++ b/language/dutch/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/filipino/index.html
+++ b/language/filipino/index.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/finnish/index.html
+++ b/language/finnish/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/french/index.html
+++ b/language/french/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/german/index.html
+++ b/language/german/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/greek/index.html
+++ b/language/greek/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 <title>403 Forbidden</title>
 </head>

--- a/language/gujarati/index.html
+++ b/language/gujarati/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/hindi/index.html
+++ b/language/hindi/index.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/hungarian/index.html
+++ b/language/hungarian/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/index.html
+++ b/language/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/indonesian/index.html
+++ b/language/indonesian/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/italian/index.html
+++ b/language/italian/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/japanese/index.html
+++ b/language/japanese/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/khmer/index.html
+++ b/language/khmer/index.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/korean/index.html
+++ b/language/korean/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/latvian/index.html
+++ b/language/latvian/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/lithuanian/index.html
+++ b/language/lithuanian/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/marathi/index.html
+++ b/language/marathi/index.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/norwegian/index.html
+++ b/language/norwegian/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/persian/index.html
+++ b/language/persian/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/polish/index.html
+++ b/language/polish/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/portuguese-brazilian/index.html
+++ b/language/portuguese-brazilian/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/portuguese/index.html
+++ b/language/portuguese/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/romanian/index.html
+++ b/language/romanian/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/russian/index.html
+++ b/language/russian/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/serbian/index.html
+++ b/language/serbian/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Zabranjeno</title>
 </head>

--- a/language/simplified-chinese/index.html
+++ b/language/simplified-chinese/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/slovak/index.html
+++ b/language/slovak/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/slovenian/index.html
+++ b/language/slovenian/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/spanish/index.html
+++ b/language/spanish/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/swedish/index.html
+++ b/language/swedish/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/tamil/index.html
+++ b/language/tamil/index.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/thai/index.html
+++ b/language/thai/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/traditional-chinese/index.html
+++ b/language/traditional-chinese/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/turkish/index.html
+++ b/language/turkish/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/ukrainian/index.html
+++ b/language/ukrainian/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/urdu/index.html
+++ b/language/urdu/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/language/vietnamese/index.html
+++ b/language/vietnamese/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>


### PR DESCRIPTION
Extract from SonarAnalyzer (HTML)

> The <html> element should provide the lang attribute in order to identify the default language of a document. It enables assistive technologies, such as screen readers, to provide a comfortable reading experience by adapting the pronunciation and accent to the language. It also helps braille translation software, telling it to switch the control codes for accented characters for instance.

https://www.w3.org/TR/WCAG20-TECHS/html.html#H57

Same as PR: https://github.com/bcit-ci/CodeIgniter/pull/5891
